### PR TITLE
Fix content length

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 os: Visual Studio 2017
 
-version: 1.1.3-alpha-{build}
+version: 1.1.4-alpha-{build}
 
 nuget:
   project_feed: true

--- a/src/MakingSense.AspNetCore.Documentation/MakingSense.AspNetCore.Documentation.csproj
+++ b/src/MakingSense.AspNetCore.Documentation/MakingSense.AspNetCore.Documentation.csproj
@@ -12,7 +12,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/MakingSense/aspnet-documentation-middleware</RepositoryUrl>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">1.1.1</RuntimeFrameworkVersion>
-    <VersionPrefix>1.1.3-alpha</VersionPrefix>
+    <VersionPrefix>1.1.4-alpha</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We were using string length (characters) in place of bytes, so, when there were special characters in layout, content length was wrong.