### PR TITLE
[DR-1478] Use FileProvider for layout and not found files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,12 @@ public class Startup
 
         app.UseStaticFiles();
 
-        var documentationFilesProvider = new PhysicalFileProvider(appEnv.ApplicationBasePath);
         app.UseDocumentation(new DocumentationOptions()
         {
             DefaultFileName = "index",
             RequestPath = "/docs",
-            NotFoundHtmlFile = documentationFilesProvider.GetFileInfo("DocumentationTemplates\\NotFound.html"),
-            LayoutFile = documentationFilesProvider.GetFileInfo("DocumentationTemplates\\Layout.html")
+            NotFoundHtmlPath = "NotFound.html",
+            LayoutFilePath = "Layout.html"
         });
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 os: Visual Studio 2017
 
-version: 1.2.0-alpha-{build}
+version: 1.2.1-alpha-{build}
 
 nuget:
   project_feed: true

--- a/src/MakingSense.AspNetCore.Documentation/DocumentationOptions.cs
+++ b/src/MakingSense.AspNetCore.Documentation/DocumentationOptions.cs
@@ -27,11 +27,14 @@ namespace MakingSense.AspNetCore.Documentation
 		public IFileProvider FileProvider { get; set; }
 
 		/// <summary>
-		/// Not found handling is disabled by default, set NotFoundHtmlFile to enable it.
+		/// Not found handling is disabled by default, set NotFoundHtmlPath to enable it.
 		/// </summary>
-		public bool EnableNotFoundHandling => NotFoundHtmlFile != null && NotFoundHtmlFile.Exists;
+		public bool EnableNotFoundHandling => NotFoundHtmlPath != null || NotFoundHtmlFile != null;
 
+		[Obsolete("Use NotFoundHtmlPath property")]
 		public IFileInfo NotFoundHtmlFile { get; set; }
+
+		public string NotFoundHtmlPath { get; set; }
 
 		/// <summary>
 		/// Default files are disabled by default, set DefaultFileName to enable it.
@@ -42,7 +45,10 @@ namespace MakingSense.AspNetCore.Documentation
 
 		public TimeSpan CacheMaxAge { get; set; }
 
+		[Obsolete("Use LayoutFilePath property")]
 		public IFileInfo LayoutFile { get; set; }
+
+		public string LayoutFilePath { get; set; }
 
 		public DirectoryOptions DirectoryOptions { get; set; } = new DirectoryOptions();
 

--- a/src/MakingSense.AspNetCore.Documentation/MakingSense.AspNetCore.Documentation.csproj
+++ b/src/MakingSense.AspNetCore.Documentation/MakingSense.AspNetCore.Documentation.csproj
@@ -12,7 +12,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/MakingSense/aspnet-documentation-middleware</RepositoryUrl>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">1.1.1</RuntimeFrameworkVersion>
-    <VersionPrefix>1.2.0-alpha</VersionPrefix>
+    <VersionPrefix>1.2.1-alpha</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Allow setting Layout and NotFound html files by path and resolved them using FileProvider inside DocumentMiddleware.

Layout.html and NotFound.html need to be located under wwwroot, to be resolved by FileProvider.

![image](https://user-images.githubusercontent.com/25298072/33442899-05b30396-d5d5-11e7-89a8-d943f9d17776.png)

![image](https://user-images.githubusercontent.com/25298072/33442926-12a356e6-d5d5-11e7-80e5-bed07f3d8097.png)
